### PR TITLE
Fix odata.nextLink typo.

### DIFF
--- a/classes/feature/usergroups/coursegroups.php
+++ b/classes/feature/usergroups/coursegroups.php
@@ -658,8 +658,8 @@ class coursegroups {
             $groupmembers[$memberrecord['id']] = $memberrecord;
         }
 
-        while (!empty($memberrecords['@odata.netxtLink'])) {
-            $nextlink = parse_url($memberrecords['@odata.netxtLink']);
+        while (!empty($memberrecords['@odata.nextLink'])) {
+            $nextlink = parse_url($memberrecords['@odata.nextLink']);
             if (isset($nextlink['query'])) {
                 $query = [];
                 parse_str($nextlink['query'], $query);


### PR DESCRIPTION
The fix for #1552 had a typo in it for the odata.nextLink for paginating results.