### PR TITLE
Also exclude for Behat

### DIFF
--- a/classes/observers.php
+++ b/classes/observers.php
@@ -911,7 +911,7 @@ class observers {
         $notificationendpoint = get_config('local_o365', 'bot_webhook_endpoint');
         if (empty($aadtenant) || empty($botappid) || empty($botappsecret) || empty($notificationendpoint)) {
             // Incomplete settings, exit.
-            if (!PHPUNIT_TEST) {
+            if (!PHPUNIT_TEST && !defined('BEHAT_SITE_RUNNING')) {
                 debugging('SKIPPED: handle_notification_sent - incomplete settings', DEBUG_DEVELOPER);
             }
             return true;


### PR DESCRIPTION
Fixes the very noisy Behat failures (60+) like this one

```
And I press "Save changes": debugging() message/s found:
SKIPPED: handle_notification_sent - incomplete settings
line 915 of /local/o365/classes/observers.php: call to debugging()
line ? of unknownfile: call to local_o365\observers::handle_notification_sent()
line 155 of /lib/classes/event/manager.php: call to call_user_func()
line 75 of /lib/classes/event/manager.php: call to core\event\manager::process_buffers()
line 834 of /lib/classes/event/base.php: call to core\event\manager::dispatch()
line 459 of /lib/classes/message/manager.php: call to core\event\base->trigger()
line 340 of /lib/classes/message/manager.php: call to core\message\manager::trigger_message_events()
line 346 of /lib/messagelib.php: call to core\message\manager::send_message()
line 6457 of /mod/assign/locallib.php: call to message_send()
line 6485 of /mod/assign/locallib.php: call to assign::send_assignment_notification()
line 6544 of /mod/assign/locallib.php: call to assign->send_notification()
line 7539 of /mod/assign/locallib.php: call to assign->notify_student_submission_receipt()
line 7576 of /mod/assign/locallib.php: call to assign->save_submission()
line 493 of /mod/assign/locallib.php: call to assign->process_save_submission()
line 55 of /mod/assign/view.php: call to assign->view()
 (Exception)
```