### PR TITLE
Fix missing string for cache store

### DIFF
--- a/lang/en/local_o365.php
+++ b/lang/en/local_o365.php
@@ -823,6 +823,9 @@ $string['o365:managegroups'] = 'View links to Microsoft 365 services and managem
 $string['o365:teammember'] = 'Team member';
 $string['o365:teamowner'] = 'Team owner';
 
+//Cache Stores.
+$string['cachedef_groups'] = 'Stores Office 365 group data.';
+
 // Web service errors.
 $string['webservices_error_assignnotfound'] = 'The received module\'s assignment record could not be found.';
 $string['webservices_error_invalidassignment'] = 'The received assignment ID cannot be used with this webservices function.';


### PR DESCRIPTION
Regression caused here - https://github.com/microsoft/moodle-local_o365/commit/8551dbc92e3b1a7381083dcca3298d3444a85b5c#diff-9c3b9ab2d183cab56b87a933e63146f67692f8e8dccfdd138f78f04a6cdadefcL152

Original Issue - https://github.com/microsoft/o365-moodle/issues/184