### PR TITLE
fix 401 unit test - sync_users

### DIFF
--- a/tests/usersync_test.php
+++ b/tests/usersync_test.php
@@ -303,7 +303,7 @@ class local_o365_usersync_testcase extends \advanced_testcase {
         $apiclient = new \local_o365\rest\unified($this->get_mock_token(), $httpclient);
         $usersync = new \local_o365\feature\usersync\main($clientdata, $httpclient);
         $users = $apiclient->get_users();
-        $usersync->sync_users($users['value']);
+        $usersync->sync_users($users);
 
         $existinguser = ['auth' => 'oidc', 'username' => 'testuser1@example.onmicrosoft.com'];
         $this->assertTrue($DB->record_exists('user', $existinguser));


### PR DESCRIPTION
When running unit tests on 401 I got the below error: 

```
local_o365_usersync_testcase::test_sync_users_create
Undefined array key "value"

/var/www/site/local/o365/tests/usersync_test.php:306
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
```

The `$users` variable is a array, there is no `value` under there, so removing that the unit tests are now passing