### PR TITLE
Fix failing webservices_onenoteassignment_testcase::test_assignment_update test in MDL4.4

### DIFF
--- a/classes/webservices/update_onenoteassignment.php
+++ b/classes/webservices/update_onenoteassignment.php
@@ -104,6 +104,7 @@ class update_onenoteassignment extends external_api {
                 'markingworkflow',
                 'markinganonymous',
                 'markingallocation',
+                'markinganonymous',
             ];
             $assigninfo = [
                 'coursemodule' => $module->id,


### PR DESCRIPTION
Running this test in Moodle 4.4 (and 4.5) results in
```

1) local_o365_webservices_onenoteassignment_testcase::test_assignment_update
- Undefined property: stdClass::$markinganonymous
```
It is due to the new markinganonymous field that has been added to the mdl_assign table since 4.4.

This PR updates the `update_onenoteassignment` class to align it with the assign table..